### PR TITLE
Fix GC Tier 3 breakthrough multiplier at PS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A mod, consisting of functional changes for Amazing Cultivation Simulator, not j
 
 * Fix Trimerous Essence Price - The Trimerous Essence Pill has a buy price and item quantity equal to equivalent items (SR pool).
 * Change Talisman of Foreseer from "Advanced Talismans" and "Luck with Talisman Room" to 96% quality, so it actually has an adventure exploration effect
+* The golden core tier 3 has a 90% chance for breakthrough at PS instead of the current 10%, more in line with the effect at T2 (100%) and T4 (25%) and its effect on breakthroughs at golden core (150% like T2).
 
 ## Install instructions
 
@@ -42,6 +43,10 @@ For example, removing the Trimerous Essence Price change requires the removal of
 
 * (MapStory_Item) Story_Item_E_FuBox - Change Talisman of Foreseer in starting experiences
 
+### Other files
+
+* Scripts\main.lua - main LUA mod loading utility
+* Scripes\fix-gc-tier3-breakthrough-multiplier.lua - GC T3 breakthrough multiplier fix
 ## How to Contribute
 
 Any Issues/Pull Requests are welcome. To ensure a similar level of quality between all parts of the mod, here's a few guidelines.

--- a/Scripts/fix-gc-tier3-breakthrough-multiplier.lua
+++ b/Scripts/fix-gc-tier3-breakthrough-multiplier.lua
@@ -1,0 +1,17 @@
+local iguana_acs_functions = GameMain:GetMod("iguana_acs_functions")
+
+function fixGCBreakthroughChange()
+    GameDefine.GlodDanEffectBroken[3][1] = 0.9
+end
+
+if iguana_acs_functions.submods == nil then
+    iguana_acs_functions.submods = {}
+end
+if iguana_acs_functions.submods["OnInit"] == nil then
+    iguana_acs_functions.submods["OnInit"] = {}
+end
+if iguana_acs_functions.submods["OnLoad"] == nil then
+    iguana_acs_functions.submods["OnLoad"] = {}
+end
+iguana_acs_functions.submods["OnInit"]["fix T3 GC Breakthrough Multiplier"] = fixGCBreakthroughChange
+iguana_acs_functions.submods["OnLoad"]["fix T3 GC Breakthrough Multiplier"] = fixGCBreakthroughChange

--- a/Scripts/main.lua
+++ b/Scripts/main.lua
@@ -1,0 +1,20 @@
+local iguana_acs_functions = GameMain:GetMod("iguana_acs_functions")
+local events = GameMain:GetMod("_Event");
+
+function functorAddSubmodInitializer(event)
+    return function ()
+        if iguana_acs_functions.submods == nil then
+            iguana_acs_functions.submods = {}
+        end
+        if iguana_acs_functions.submods[event] == nil then
+            iguana_acs_functions.submods[event] = {}
+        end
+        for title, submodFunc in pairs( iguana_acs_functions.submods[event]) do
+            print("iguana_acs_functions:"..event..": calling submod func "..title)
+            submodFunc()
+        end
+    end
+end
+
+iguana_acs_functions.OnInit = functorAddSubmodInitializer("OnInit")
+iguana_acs_functions.OnLoad = functorAddSubmodInitializer("OnLoad")

--- a/source/test/fix-gc-tier3-breakthrough-multiplier.lua
+++ b/source/test/fix-gc-tier3-breakthrough-multiplier.lua
@@ -1,0 +1,26 @@
+--preliminary code to run
+local g = GameMain:GetMod("TestMod")
+
+function funcAsserter(descriptor, callback)
+    return function (title, firstValue, secondValue, verbose)
+        if verbose == nil then
+            verbose = false
+        end
+        local result = callback(firstValue,secondValue)
+        local text = tostring(result).." "..title
+        if verbose then
+            text = text.." | "..tostring(firstValue).." "..descriptor.." "..tostring(secondValue)
+        end
+        print(text)
+        return result
+    end
+end
+g.assert = funcAsserter("is equal to", function (a, b) return a == b end)
+g.assertLessThan = funcAsserter("is less than", function (a, b) return a < b end)
+
+function test_tier3BreakthroughMultiplier()
+    local g = GameMain:GetMod("TestMod")
+    g.assert("breakthrough chance at GC for T3 is unchanged", GameDefine.GlodDanEffectBroken[3][0], 1.5)
+    g.assertLessThan("breakthrough chance at PS for T3 is ~90%", math.abs(GameDefine.GlodDanEffectBroken[3][1] - 0.9), 0.0001)
+end
+test_tier3BreakthroughMultiplier()


### PR DESCRIPTION
Fixes #4 

The chosen value was done using those assumptions :
* Tier 3 is in a similar category of Golden core as Tier 1 and 2, as shown by its 150% value for GC breakthroughs.
* The differential between tiers of the same category gradually widens (3% for low tier, 5% for mid tier), so a higher value is to be expected
* (a bit flimsy) The base game value, 0.1, could be interpreted as a mistaken "- 10%" intention

Other more drastically lower values like 50% would obviously be fine with me too, but I don't think it would be in line with the 150% value from GC.