### PR TITLE
sync perfect alignment moodlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A mod, consisting of functional changes for Amazing Cultivation Simulator, not j
 * Skill Level Everywhere - Displays Skill Level instead of Ability Rating ([Standalone mod](https://www.nexusmods.com/amazingcultivationsimulator/mods/20/))
 * Story Button Interaction Change - Changes the interaction with Ancient Caskets and Festive Goods, making it select an opener randomly.
 * Sort Manuals by Attainment - Sorts the manuals by ascending attainment in the Manual Library. Also displays a small element icon next to manuals. Takes into account the element of the cultivator if any ([Standalone mod](https://www.nexusmods.com/amazingcultivationsimulator/mods/21/))
+* Sync Perfect Alignment moodlet - the perfect alignment moodlet is changed to trigger at the same element strength (1.85) as optimal cultivation speed and golden core
+
 ## Install instructions
 
 Download the latest release, extract the iguana_acs_functions into the Mods folder. If the release is behind the Main version and you want to update to the preview version, download the repository directly, and extract the contents of the archive into the iguana_acs_functions folder, located in the Mods folder.
@@ -54,6 +56,7 @@ For example, removing the Trimerous Essence Price change requires the removal of
 
 * Scripts\main.lua - main LUA mod loading utility
 * Scripts\fix-gc-tier3-breakthrough-multiplier.lua - GC T3 breakthrough multiplier fix
+* Scripts\sync-perfect-alignment-moodlet.lua - Sync Perfect Alignment moodlet
 * iguana_acs_functions.dll - Skill Level Everywhere, Sort Manuals By Attainment
 
 ## How to Contribute
@@ -67,4 +70,4 @@ If the fixes exist as a standalone mod, include a link to it.
 
 ## Credits/Contributions
 
-* ucddj - Trimerous Essence Price, FuBox change, Skill Level Everywhere, Sort Manuals by Attainment
+* ucddj - Trimerous Essence Price, FuBox change, Skill Level Everywhere, Sort Manuals by Attainment, Sync Perfect Alignment moodlet

--- a/Scripts/sync-perfect-alignment-moodlet.lua
+++ b/Scripts/sync-perfect-alignment-moodlet.lua
@@ -1,0 +1,27 @@
+local iguana_acs_functions = GameMain:GetMod("iguana_acs_functions")
+
+function syncPerfectAlignmentMoodlet()
+    -- It is not possible to simply remove the first key and add it back with a proper value
+    -- as GetValueByMap iterates over the dictionary with foreach, which, in the game's (and current's ) .NET
+    -- implementation, loops by order of key insertion (https://stackoverflow.com/questions/32892313/system-collections-generic-dictionary-foreach-order)
+    -- so the dictionary has to be recreated entirely
+    local Dictionary_Float_String = CS.System.Collections.Generic.Dictionary(CS.System.Single, CS.System.String)
+    local dictReplacement = Dictionary_Float_String()
+    dictReplacement:Add(1.85, "PracticeElement1")
+    dictReplacement:Add(0.6, "PracticeElement2")
+    dictReplacement:Add(0, "PracticeElement3")
+    dictReplacement:Add(-2, "PracticeElement4")
+    GameDefine.PracticeElement2MoonNameMap = dictReplacement
+end
+
+if iguana_acs_functions.submods == nil then
+    iguana_acs_functions.submods = {}
+end
+if iguana_acs_functions.submods["OnInit"] == nil then
+    iguana_acs_functions.submods["OnInit"] = {}
+end
+if iguana_acs_functions.submods["OnLoad"] == nil then
+    iguana_acs_functions.submods["OnLoad"] = {}
+end
+iguana_acs_functions.submods["OnInit"]["Sync perfect alignment moodlet"] = syncPerfectAlignmentMoodlet
+iguana_acs_functions.submods["OnLoad"]["Sync perfect alignment moodlet"] = syncPerfectAlignmentMoodlet

--- a/source/test/sync-perfect-alignment-moodlet.lua
+++ b/source/test/sync-perfect-alignment-moodlet.lua
@@ -1,0 +1,41 @@
+--preliminary code to run
+local g = GameMain:GetMod("TestMod")
+
+function funcAsserter(descriptor, callback)
+    return function (title, firstValue, secondValue, verbose)
+        if verbose == nil then
+            verbose = false
+        end
+        local result = callback(firstValue,secondValue)
+        local text = tostring(result).." "..title
+        if verbose then
+            text = text.." | "..tostring(firstValue).." "..descriptor.." "..tostring(secondValue)
+        end
+        print(text)
+        return result
+    end
+end
+g.assert = funcAsserter("is equal to", function (a, b) return a == b end)
+g.assertLessThan = funcAsserter("is less than", function (a, b) return a < b end)
+
+function GetValueByMap(tbMap, Key)
+    -- we do like other lua scripts and implement our own getvaluebymap
+    -- as generics don't have full support for xlua
+	local Value
+	for k, v in pairs(tbMap) do
+		if Key >= k then
+			return v
+		end
+		Value = v
+	end
+	return Value
+end
+
+function test()
+    local g = GameMain:GetMod("TestMod")
+    g.assert("1.87 returns the max value",GetValueByMap(GameDefine.PracticeElement2MoonNameMap, 1.87), "PracticeElement1")
+    g.assert("1.84 returns the 2nd value",GetValueByMap(GameDefine.PracticeElement2MoonNameMap, 1.84), "PracticeElement2")
+    g.assert("0 returns the 3rd value",GetValueByMap(GameDefine.PracticeElement2MoonNameMap, 0), "PracticeElement3")
+    g.assert("-1 returns the last value",GetValueByMap(GameDefine.PracticeElement2MoonNameMap, -1), "PracticeElement4")
+end
+test()


### PR DESCRIPTION
Fixes #17 .

Copying the comment from the fix:
It is not possible to simply remove the first key and add it back with a proper value as GetValueByMap iterates over the dictionary with foreach, which, in the game's (and current's ) .NET implementation, loops by order of key insertion 
 (https://stackoverflow.com/questions/32892313/system-collections-generic-dictionary-foreach-order) so the dictionary has to be recreated entirely.

It is also not possible (or easy) to test with the game's `GetValueByMap` as those specific generic methods are unsupported by xlua (https://github.com/Tencent/xLua/blob/master/Assets/XLua/Examples/09_GenericMethod/Foo.cs). I may have misunderstood that part, but as every other lua file I've seen reimplements it, I suppose that's a common issue.