### PR TITLE
Fix #52: overlapping of Price and Connection text.

### DIFF
--- a/Scripts/misc.lua
+++ b/Scripts/misc.lua
@@ -65,9 +65,9 @@ local function SetTradeValueVisible( ctx )
 	local enabled = CS.iguana_acs_functions.Miscellaneous.Enabled.showTradeValue;
 
 	if not ctx.sender.contentPane.m_itemvalue.visible and enabled then
-		if itemVal_oldY == 0 then
-			itemVal_oldY = ctx.sender.contentPane.m_friendpontvalue.y - 50
-			ctx.sender.contentPane.m_itemvalue.y = itemVal_oldY
+		if itemVal_Y == 0 then
+			itemVal_Y = ctx.sender.contentPane.m_friendpontvalue.y - ctx.sender.contentPane.m_friendpontvalue.actualHeight
+			ctx.sender.contentPane.m_itemvalue.y = itemVal_Y
 		end
 		ctx.sender.contentPane.m_itemvalue.visible = true
 	end


### PR DESCRIPTION
[ #52 ] -- `ItemVal_Y` was declared but never used, and inside `SetTradeValueVisible` i used `ItemVal_OldY` instead of `ItemVal_Y` (negligence i guess). also changed the hardcoded value of `m_friendpontvalue.y - 50`, with `m_friendpontvalue.y - m_friendpontvalue.actualHeight` to ensure the Value text remains at same position across different resolutions(screen ratios).